### PR TITLE
callback w/ no params for success case and readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ var gulpRequireSafe = require('gulp-requiresafe');
 
 //To check your project
 gulp.task('requiresafe', function (cb) {
-  var package = fs.readFileSync('./package.json'); // probably don't actually do this.
-  gulpRequireSafe({package: package}, cb);
+  gulpRequireSafe({package: __dirname + '/package.json'}, cb);
+});
+```
+
+//If you're using a shrinkwrap file
+gulp.task('requiresafe', function (cb) {
+  gulpRequireSafe({shrinkwrap: __dirname + '/npm-shrinkwrap.json'}, cb);
 });
 ```
 
@@ -25,7 +30,7 @@ If you don't want to stop your gulp flow if some vulnerabilities have been found
 ```
 gulp.task('requiresafe', function (cb) {
   gulpRequireSafe({
-    path: './',
+    package: __dirname + '/package.json',
     stopOnError: false
   }, cb);
 });

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ var rsGulp = function (params, callback) {
       stack = stack + Chalk.red('(+) ') + data.length + ' vulnerabilities found\n';
     }
 
-    if (params.stopOnError === false) {
+    if (params.stopOnError === false || data.length === 0) {
       GulpUtil.log(stack);
       return callback();
     };


### PR DESCRIPTION
The current success case calls callback with params and thus rejects the build. Also fixed the readme so that we are passing in the package.json path and added shrinkwrap example.
