### PR TITLE
Removing unnecessary semicolon

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ var rsGulp = function (params, callback) {
     if (params.stopOnError === false) {
       GulpUtil.log(stack);
       return callback();
-    };
+    }
 
     return callback({
       stack: stack,


### PR DESCRIPTION
```
/Users/pdehaan/dev/tmp/del/gulp-requiresafe/index.js
  60:6  error  Unnecessary semicolon  no-extra-semi
```
