### PR TITLE
Moves gulp-util to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "cli-table": "^0.3.1",
+    "gulp-util": "^3.0.6",
     "nsp": "^2.0.0"
   },
   "devDependencies": {
@@ -33,7 +34,6 @@
     "eslint": "^1.7.3",
     "eslint-config-requiresafe": "1.0.0",
     "gulp": "^3.9.0",
-    "gulp-util": "^3.0.6",
     "lab": "^6.2.0",
     "shrinkydink": "^1.0.0"
   },


### PR DESCRIPTION
`index.js`, on [line 3](https://github.com/nodesecurity/gulp-nsp/blob/master/index.js#L3), indicates that `gulp-util` is a dependency, not a devDependency. This PR moves `gulp-util` from `devDependencies` to `dependencies`. 

I have not edited `npm-shrinkwrap.json` for the simple reason that I've never used `npm shrinkwrap` before, and therefore I don't know if this PR should edit `npm-shrinkwrap.json` as well. 
