### PR TITLE
Move gulp-util to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-nsp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A gulp plugin that runs Node Security check",
   "main": "index.js",
   "scripts": {
@@ -26,6 +26,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "cli-table": "^0.3.1",
+    "gulp-util": "^3.0.6",
     "nsp": "^2.0.0"
   },
   "devDependencies": {
@@ -33,7 +34,6 @@
     "eslint": "^1.7.3",
     "eslint-config-requiresafe": "1.0.0",
     "gulp": "^3.9.0",
-    "gulp-util": "^3.0.6",
     "lab": "^6.2.0",
     "shrinkydink": "^1.0.0"
   },


### PR DESCRIPTION
This PR moves `gulp-util` to the `dependencies` section instead of the `devDependencies` section as it is used within the `index.js` file. The current setup causes failures when attempting to use `gulp-nsp` due to it not having `gulp-util` installed.
