### PR TITLE
Enable builds behind the HTTP_PROXY

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,11 @@ var rsGulp = function (params, callback) {
     payload.shrinkwrap = params.shrinkwrap;
   }
 
+  // Enable builds behind the HTTP_PROXY
+  if (params.proxy) {
+    payload.proxy = params.proxy;
+  }
+
   if (params.output) {
     if (Nsp.formatters.hasOwnProperty(params.output)) {
       formatter = Nsp.formatters[params.output];


### PR DESCRIPTION
In order to build behind the proxy, the NSP API can take the proxy parameter. 

The documentation is related to https://github.com/nodesecurity/nodesecurity.io/pull/62.
