### PR TITLE
No longer using gulp-util as it is deprecated, closes #41

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var GulpUtil = require('gulp-util');
 var Nsp = require('nsp');
+var PluginError = require('plugin-error');
+var Log = require('fancy-log');
 var PLUGIN_NAME = require('./package.json').name;
 
 var rsGulp = function (params, callback) {
@@ -27,25 +28,25 @@ var rsGulp = function (params, callback) {
       formatter = Nsp.formatters[params.output];
     }
     else {
-      GulpUtil.log('Invalid formatter specified in options. Must be one of ' + Object.keys(Nsp.formatters).join(', ') + '\nUsing default formatter');
+      Log('Invalid formatter specified in options. Must be one of ' + Object.keys(Nsp.formatters).join(', ') + '\nUsing default formatter');
     }
   }
 
   Nsp.check(payload, function (err, data) {
 
     var output = formatter(err, data);
-    var pluginErr = new GulpUtil.PluginError(PLUGIN_NAME, output);
+    var pluginErr = new PluginError(PLUGIN_NAME, output);
 
     if (err) {
       if (params.stopOnError === false) {
-        GulpUtil.log(output);
+        Log(output);
         return callback();
       }
       return callback(pluginErr);
     }
 
     if (params.stopOnError === false || data && data.length === 0) {
-      GulpUtil.log(output);
+      Log(output);
       return callback();
     }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,1009 +2,1454 @@
   "name": "gulp-nsp",
   "version": "2.4.2",
   "dependencies": {
-    "gulp-util": {
-      "version": "3.0.7",
+    "acorn": {
+      "version": "5.4.1"
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
       "dependencies": {
-        "array-differ": {
-          "version": "1.0.0"
+        "acorn": {
+          "version": "3.3.0"
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8"
+    },
+    "ajv-keywords": {
+      "version": "1.5.1"
+    },
+    "ansi-colors": {
+      "version": "1.0.1"
+    },
+    "ansi-escapes": {
+      "version": "1.4.0"
+    },
+    "ansi-gray": {
+      "version": "0.1.1"
+    },
+    "ansi-regex": {
+      "version": "2.1.1"
+    },
+    "ansi-styles": {
+      "version": "2.2.1"
+    },
+    "ansi-wrap": {
+      "version": "0.1.0"
+    },
+    "archy": {
+      "version": "1.0.0"
+    },
+    "argparse": {
+      "version": "1.0.9"
+    },
+    "arr-diff": {
+      "version": "4.0.0"
+    },
+    "arr-flatten": {
+      "version": "1.1.0"
+    },
+    "arr-union": {
+      "version": "3.1.0"
+    },
+    "array-differ": {
+      "version": "1.0.0"
+    },
+    "array-each": {
+      "version": "1.0.1"
+    },
+    "array-slice": {
+      "version": "1.1.0"
+    },
+    "array-union": {
+      "version": "1.0.2"
+    },
+    "array-uniq": {
+      "version": "1.0.3"
+    },
+    "array-unique": {
+      "version": "0.3.2"
+    },
+    "arrify": {
+      "version": "1.0.1"
+    },
+    "assign-symbols": {
+      "version": "1.0.0"
+    },
+    "atob": {
+      "version": "2.0.3"
+    },
+    "balanced-match": {
+      "version": "1.0.0"
+    },
+    "base": {
+      "version": "0.11.2"
+    },
+    "beeper": {
+      "version": "1.1.1"
+    },
+    "brace-expansion": {
+      "version": "1.1.11"
+    },
+    "braces": {
+      "version": "2.3.0"
+    },
+    "cache-base": {
+      "version": "1.0.1"
+    },
+    "caller-path": {
+      "version": "0.1.0"
+    },
+    "callsites": {
+      "version": "0.2.0"
+    },
+    "chalk": {
+      "version": "1.1.3"
+    },
+    "circular-json": {
+      "version": "0.3.3"
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5"
         },
-        "array-uniq": {
-          "version": "1.0.2"
+        "is-descriptor": {
+          "version": "0.1.6"
         },
-        "beeper": {
-          "version": "1.1.0"
+        "kind-of": {
+          "version": "5.1.0"
         },
-        "chalk": {
-          "version": "1.1.3",
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0"
+            "kind-of": {
+              "version": "3.2.2"
             }
           }
         },
-        "dateformat": {
-          "version": "1.0.12",
+        "is-data-descriptor": {
+          "version": "0.1.4",
           "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1"
-            },
-            "meow": {
-              "version": "3.7.0",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "2.1.0",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "2.1.1"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0"
-                },
-                "loud-rejection": {
-                  "version": "1.3.0",
-                  "dependencies": {
-                    "array-find-index": {
-                      "version": "1.0.1"
-                    },
-                    "signal-exit": {
-                      "version": "2.1.2"
-                    }
-                  }
-                },
-                "map-obj": {
-                  "version": "1.0.1"
-                },
-                "normalize-package-data": {
-                  "version": "2.3.5",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "2.1.4"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "builtin-modules": {
-                          "version": "1.1.1"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.1.0"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "dependencies": {
-                        "spdx-correct": {
-                          "version": "1.0.2",
-                          "dependencies": {
-                            "spdx-license-ids": {
-                              "version": "1.2.0"
-                            }
-                          }
-                        },
-                        "spdx-expression-parse": {
-                          "version": "1.0.2",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.4"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.0.1"
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.3"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.0",
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.3"
-                            },
-                            "pify": {
-                              "version": "2.3.0"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "redent": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "indent-string": {
-                      "version": "2.1.0",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-indent": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "trim-newlines": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "fancy-log": {
-          "version": "1.2.0",
-          "dependencies": {
-            "time-stamp": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "gulplog": {
-          "version": "1.0.0",
-          "dependencies": {
-            "glogg": {
-              "version": "1.0.0",
-              "dependencies": {
-                "sparkles": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "has-gulplog": {
-          "version": "0.1.0",
-          "dependencies": {
-            "sparkles": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "lodash._reescape": {
-          "version": "3.0.0"
-        },
-        "lodash._reevaluate": {
-          "version": "3.0.0"
-        },
-        "lodash._reinterpolate": {
-          "version": "3.0.0"
-        },
-        "lodash.template": {
-          "version": "3.6.2",
-          "dependencies": {
-            "lodash._basecopy": {
-              "version": "3.0.1"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1"
-            },
-            "lodash._basevalues": {
-              "version": "3.0.0"
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9"
-            },
-            "lodash.escape": {
-              "version": "3.2.0",
-              "dependencies": {
-                "lodash._root": {
-                  "version": "3.0.1"
-                }
-              }
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1"
-            },
-            "lodash.templatesettings": {
-              "version": "3.1.1"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0"
-        },
-        "multipipe": {
-          "version": "0.1.2",
-          "dependencies": {
-            "duplexer2": {
-              "version": "0.0.2",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0"
-        },
-        "replace-ext": {
-          "version": "0.0.1"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "isarray": {
-                  "version": "1.0.0"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1"
-            }
-          }
-        },
-        "vinyl": {
-          "version": "0.5.3",
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2"
-            },
-            "clone-stats": {
-              "version": "0.0.1"
+            "kind-of": {
+              "version": "3.2.2"
             }
           }
         }
       }
     },
-    "nsp": {
-      "version": "2.3.0",
+    "cli-cursor": {
+      "version": "1.0.2"
+    },
+    "cli-width": {
+      "version": "2.2.0"
+    },
+    "clone": {
+      "version": "1.0.3"
+    },
+    "clone-stats": {
+      "version": "0.0.1"
+    },
+    "co": {
+      "version": "4.6.0"
+    },
+    "code-point-at": {
+      "version": "1.1.0"
+    },
+    "collection-visit": {
+      "version": "1.0.0"
+    },
+    "color-support": {
+      "version": "1.1.3"
+    },
+    "component-emitter": {
+      "version": "1.2.1"
+    },
+    "concat-map": {
+      "version": "0.0.1"
+    },
+    "concat-stream": {
+      "version": "1.6.0",
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0"
-            }
-          }
+        "readable-stream": {
+          "version": "2.3.4"
         },
-        "cli-table": {
-          "version": "0.3.1",
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3"
-            }
-          }
-        },
-        "https-proxy-agent": {
-          "version": "1.0.0",
-          "dependencies": {
-            "agent-base": {
-              "version": "2.0.1",
-              "dependencies": {
-                "semver": {
-                  "version": "5.0.3"
-                }
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0"
-            }
-          }
-        },
-        "joi": {
-          "version": "6.10.1",
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3"
-            },
-            "topo": {
-              "version": "1.1.0"
-            },
-            "isemail": {
-              "version": "1.2.0"
-            },
-            "moment": {
-              "version": "2.12.0"
-            }
-          }
-        },
-        "nodesecurity-npm-utils": {
-          "version": "4.0.1",
-          "dependencies": {
-            "silent-npm-registry-client": {
-              "version": "2.0.0",
-              "dependencies": {
-                "npm-registry-client": {
-                  "version": "7.1.0",
-                  "dependencies": {
-                    "chownr": {
-                      "version": "1.0.1"
-                    },
-                    "concat-stream": {
-                      "version": "1.5.1",
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.1"
-                        },
-                        "typedarray": {
-                          "version": "0.0.6"
-                        },
-                        "readable-stream": {
-                          "version": "2.0.6",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "isarray": {
-                              "version": "1.0.0"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.6"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8"
-                        }
-                      }
-                    },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "dependencies": {
-                        "hosted-git-info": {
-                          "version": "2.1.4"
-                        },
-                        "is-builtin-module": {
-                          "version": "1.0.0",
-                          "dependencies": {
-                            "builtin-modules": {
-                              "version": "1.1.1"
-                            }
-                          }
-                        },
-                        "validate-npm-package-license": {
-                          "version": "3.0.1",
-                          "dependencies": {
-                            "spdx-correct": {
-                              "version": "1.0.2",
-                              "dependencies": {
-                                "spdx-license-ids": {
-                                  "version": "1.2.0"
-                                }
-                              }
-                            },
-                            "spdx-expression-parse": {
-                              "version": "1.0.2",
-                              "dependencies": {
-                                "spdx-exceptions": {
-                                  "version": "1.0.4"
-                                },
-                                "spdx-license-ids": {
-                                  "version": "1.2.0"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "npm-package-arg": {
-                      "version": "4.1.0",
-                      "dependencies": {
-                        "hosted-git-info": {
-                          "version": "2.1.4"
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "request": {
-                      "version": "2.69.0",
-                      "dependencies": {
-                        "aws-sign2": {
-                          "version": "0.6.0"
-                        },
-                        "aws4": {
-                          "version": "1.3.2",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "4.0.1",
-                              "dependencies": {
-                                "pseudomap": {
-                                  "version": "1.0.2"
-                                },
-                                "yallist": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "bl": {
-                          "version": "1.0.3",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "2.0.6",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1"
-                                },
-                                "isarray": {
-                                  "version": "1.0.0"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "caseless": {
-                          "version": "0.11.0"
-                        },
-                        "combined-stream": {
-                          "version": "1.0.5",
-                          "dependencies": {
-                            "delayed-stream": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "extend": {
-                          "version": "3.0.0"
-                        },
-                        "forever-agent": {
-                          "version": "0.6.1"
-                        },
-                        "form-data": {
-                          "version": "1.0.0-rc4",
-                          "dependencies": {
-                            "async": {
-                              "version": "1.5.2"
-                            }
-                          }
-                        },
-                        "har-validator": {
-                          "version": "2.0.6",
-                          "dependencies": {
-                            "commander": {
-                              "version": "2.9.0",
-                              "dependencies": {
-                                "graceful-readlink": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "is-my-json-valid": {
-                              "version": "2.13.1",
-                              "dependencies": {
-                                "generate-function": {
-                                  "version": "2.0.0"
-                                },
-                                "generate-object-property": {
-                                  "version": "1.2.0",
-                                  "dependencies": {
-                                    "is-property": {
-                                      "version": "1.0.2"
-                                    }
-                                  }
-                                },
-                                "jsonpointer": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "hawk": {
-                          "version": "3.1.3",
-                          "dependencies": {
-                            "hoek": {
-                              "version": "2.16.3"
-                            },
-                            "boom": {
-                              "version": "2.10.1"
-                            },
-                            "cryptiles": {
-                              "version": "2.0.5"
-                            },
-                            "sntp": {
-                              "version": "1.0.9"
-                            }
-                          }
-                        },
-                        "http-signature": {
-                          "version": "1.1.1",
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "0.2.0"
-                            },
-                            "jsprim": {
-                              "version": "1.2.2",
-                              "dependencies": {
-                                "extsprintf": {
-                                  "version": "1.0.2"
-                                },
-                                "json-schema": {
-                                  "version": "0.2.2"
-                                },
-                                "verror": {
-                                  "version": "1.3.6"
-                                }
-                              }
-                            },
-                            "sshpk": {
-                              "version": "1.7.4",
-                              "dependencies": {
-                                "asn1": {
-                                  "version": "0.2.3"
-                                },
-                                "dashdash": {
-                                  "version": "1.13.0",
-                                  "dependencies": {
-                                    "assert-plus": {
-                                      "version": "1.0.0"
-                                    }
-                                  }
-                                },
-                                "jsbn": {
-                                  "version": "0.1.0"
-                                },
-                                "tweetnacl": {
-                                  "version": "0.14.3"
-                                },
-                                "jodid25519": {
-                                  "version": "1.0.2"
-                                },
-                                "ecc-jsbn": {
-                                  "version": "0.1.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-typedarray": {
-                          "version": "1.0.0"
-                        },
-                        "isstream": {
-                          "version": "0.1.2"
-                        },
-                        "json-stringify-safe": {
-                          "version": "5.0.1"
-                        },
-                        "mime-types": {
-                          "version": "2.1.10",
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.22.0"
-                            }
-                          }
-                        },
-                        "node-uuid": {
-                          "version": "1.4.7"
-                        },
-                        "oauth-sign": {
-                          "version": "0.8.1"
-                        },
-                        "qs": {
-                          "version": "6.0.2"
-                        },
-                        "stringstream": {
-                          "version": "0.0.5"
-                        },
-                        "tough-cookie": {
-                          "version": "2.2.2"
-                        },
-                        "tunnel-agent": {
-                          "version": "0.4.2"
-                        }
-                      }
-                    },
-                    "retry": {
-                      "version": "0.8.0"
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.0.3",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "slide": {
-                      "version": "1.1.6"
-                    },
-                    "npmlog": {
-                      "version": "2.0.3",
-                      "dependencies": {
-                        "ansi": {
-                          "version": "0.3.1"
-                        },
-                        "are-we-there-yet": {
-                          "version": "1.1.2",
-                          "dependencies": {
-                            "delegates": {
-                              "version": "1.0.0"
-                            },
-                            "readable-stream": {
-                              "version": "2.0.6",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1"
-                                },
-                                "isarray": {
-                                  "version": "1.0.0"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "gauge": {
-                          "version": "1.2.7",
-                          "dependencies": {
-                            "has-unicode": {
-                              "version": "2.0.0"
-                            },
-                            "lodash.pad": {
-                              "version": "4.1.0",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "4.0.0"
-                                },
-                                "lodash.tostring": {
-                                  "version": "4.1.2"
-                                }
-                              }
-                            },
-                            "lodash.padend": {
-                              "version": "4.2.0",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "4.0.0"
-                                },
-                                "lodash.tostring": {
-                                  "version": "4.1.2"
-                                }
-                              }
-                            },
-                            "lodash.padstart": {
-                              "version": "4.2.0",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "4.0.0"
-                                },
-                                "lodash.tostring": {
-                                  "version": "4.1.2"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            }
-          }
-        },
-        "path-is-absolute": {
+        "isarray": {
           "version": "1.0.0"
         },
-        "rc": {
-          "version": "1.1.6",
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.4.1"
-            },
-            "ini": {
-              "version": "1.3.4"
-            },
-            "minimist": {
-              "version": "1.2.0"
-            },
-            "strip-json-comments": {
-              "version": "1.0.4"
-            }
-          }
+        "string_decoder": {
+          "version": "1.0.3"
+        }
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1"
+    },
+    "core-util-is": {
+      "version": "1.0.2"
+    },
+    "d": {
+      "version": "1.0.0"
+    },
+    "dateformat": {
+      "version": "2.2.0"
+    },
+    "debug": {
+      "version": "2.6.9"
+    },
+    "decode-uri-component": {
+      "version": "0.2.0"
+    },
+    "deep-is": {
+      "version": "0.1.3"
+    },
+    "defaults": {
+      "version": "1.0.3"
+    },
+    "define-property": {
+      "version": "1.0.0"
+    },
+    "del": {
+      "version": "2.2.2",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1"
+        }
+      }
+    },
+    "deprecated": {
+      "version": "0.0.1"
+    },
+    "detect-file": {
+      "version": "1.0.0"
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "duplexer2": {
+      "version": "0.0.2"
+    },
+    "end-of-stream": {
+      "version": "0.1.5",
+      "dependencies": {
+        "once": {
+          "version": "1.3.3"
+        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.38"
+    },
+    "es6-iterator": {
+      "version": "2.0.3"
+    },
+    "es6-map": {
+      "version": "0.1.5"
+    },
+    "es6-set": {
+      "version": "0.1.5"
+    },
+    "es6-symbol": {
+      "version": "3.1.1"
+    },
+    "es6-weak-map": {
+      "version": "2.0.2"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5"
+    },
+    "escope": {
+      "version": "3.6.0"
+    },
+    "espree": {
+      "version": "3.5.3"
+    },
+    "esprima": {
+      "version": "4.0.0"
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1"
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0"
+    },
+    "estraverse-fb": {
+      "version": "1.3.2"
+    },
+    "esutils": {
+      "version": "2.0.2"
+    },
+    "event-emitter": {
+      "version": "0.3.5"
+    },
+    "exit-hook": {
+      "version": "1.1.1"
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5"
         },
-        "semver": {
+        "is-descriptor": {
+          "version": "0.1.6"
+        },
+        "kind-of": {
           "version": "5.1.0"
         },
-        "subcommand": {
-          "version": "2.0.3",
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
           "dependencies": {
-            "cliclopts": {
-              "version": "1.1.1"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1"
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0"
-            },
-            "xtend": {
-              "version": "4.0.1"
+            "kind-of": {
+              "version": "3.2.2"
             }
           }
         },
-        "wreck": {
-          "version": "6.3.0",
+        "is-data-descriptor": {
+          "version": "0.1.4",
           "dependencies": {
-            "hoek": {
-              "version": "2.16.3"
-            },
-            "boom": {
-              "version": "2.10.1"
+            "kind-of": {
+              "version": "3.2.2"
             }
           }
         }
       }
+    },
+    "expand-tilde": {
+      "version": "2.0.2"
+    },
+    "extend": {
+      "version": "3.0.1"
+    },
+    "extend-shallow": {
+      "version": "2.0.1"
+    },
+    "extglob": {
+      "version": "2.0.4"
+    },
+    "fancy-log": {
+      "version": "1.3.2"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6"
+    },
+    "figures": {
+      "version": "1.7.0",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1"
+        }
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1"
+        }
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0"
+    },
+    "find-index": {
+      "version": "0.1.1"
+    },
+    "findup-sync": {
+      "version": "2.0.0"
+    },
+    "fined": {
+      "version": "1.1.0"
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0"
+    },
+    "flagged-respawn": {
+      "version": "1.0.0"
+    },
+    "flat-cache": {
+      "version": "1.3.0"
+    },
+    "for-in": {
+      "version": "1.0.2"
+    },
+    "for-own": {
+      "version": "1.0.0"
+    },
+    "fragment-cache": {
+      "version": "0.2.1"
+    },
+    "fs.realpath": {
+      "version": "1.0.0"
+    },
+    "gaze": {
+      "version": "0.5.2"
+    },
+    "generate-function": {
+      "version": "2.0.0"
+    },
+    "generate-object-property": {
+      "version": "1.2.0"
+    },
+    "get-value": {
+      "version": "2.0.6"
+    },
+    "glob": {
+      "version": "7.1.2"
+    },
+    "glob-stream": {
+      "version": "3.1.18",
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3"
+        },
+        "minimatch": {
+          "version": "2.0.10"
+        },
+        "through2": {
+          "version": "0.6.5"
+        },
+        "readable-stream": {
+          "version": "1.0.34"
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "0.0.6"
+    },
+    "glob2base": {
+      "version": "0.0.12"
+    },
+    "global-modules": {
+      "version": "1.0.0"
+    },
+    "global-prefix": {
+      "version": "1.0.2"
+    },
+    "globals": {
+      "version": "9.18.0"
+    },
+    "globby": {
+      "version": "5.0.0",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1"
+        }
+      }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "dependencies": {
+        "glob": {
+          "version": "3.1.21"
+        },
+        "lodash": {
+          "version": "1.0.2"
+        },
+        "minimatch": {
+          "version": "0.2.14"
+        },
+        "graceful-fs": {
+          "version": "1.2.3"
+        },
+        "inherits": {
+          "version": "1.0.2"
+        }
+      }
+    },
+    "glogg": {
+      "version": "1.0.1"
+    },
+    "graceful-fs": {
+      "version": "4.1.11"
+    },
+    "gulp-util": {
+      "version": "3.0.8"
+    },
+    "gulplog": {
+      "version": "1.0.0"
+    },
+    "hapi-capitalize-modules": {
+      "version": "1.1.6"
+    },
+    "hapi-for-you": {
+      "version": "1.0.0"
+    },
+    "hapi-no-var": {
+      "version": "1.0.1"
+    },
+    "hapi-scope-start": {
+      "version": "2.1.1"
+    },
+    "has-ansi": {
+      "version": "2.0.0"
+    },
+    "has-gulplog": {
+      "version": "0.1.0"
+    },
+    "has-value": {
+      "version": "1.0.0"
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0"
+        }
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1"
+    },
+    "ignore": {
+      "version": "3.3.7"
+    },
+    "imurmurhash": {
+      "version": "0.1.4"
+    },
+    "inflight": {
+      "version": "1.0.6"
+    },
+    "inherits": {
+      "version": "2.0.3"
+    },
+    "ini": {
+      "version": "1.3.5"
+    },
+    "inquirer": {
+      "version": "0.12.0"
+    },
+    "interpret": {
+      "version": "1.1.0"
+    },
+    "is-absolute": {
+      "version": "1.0.0"
+    },
+    "is-accessor-descriptor": {
+      "version": "1.0.0"
+    },
+    "is-buffer": {
+      "version": "1.1.6"
+    },
+    "is-data-descriptor": {
+      "version": "1.0.0"
+    },
+    "is-descriptor": {
+      "version": "1.0.2"
+    },
+    "is-extendable": {
+      "version": "0.1.1"
+    },
+    "is-extglob": {
+      "version": "2.1.1"
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0"
+    },
+    "is-glob": {
+      "version": "3.1.0"
+    },
+    "is-my-json-valid": {
+      "version": "2.17.1"
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2"
+        }
+      }
+    },
+    "is-odd": {
+      "version": "1.0.0"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-inside": {
+      "version": "1.0.1"
+    },
+    "is-plain-object": {
+      "version": "2.0.4"
+    },
+    "is-property": {
+      "version": "1.0.2"
+    },
+    "is-relative": {
+      "version": "1.0.0"
+    },
+    "is-resolvable": {
+      "version": "1.1.0"
+    },
+    "is-unc-path": {
+      "version": "1.0.0"
+    },
+    "is-utf8": {
+      "version": "0.2.1"
+    },
+    "is-windows": {
+      "version": "1.0.1"
+    },
+    "isarray": {
+      "version": "0.0.1"
+    },
+    "isexe": {
+      "version": "2.0.0"
+    },
+    "isobject": {
+      "version": "3.0.1"
+    },
+    "js-yaml": {
+      "version": "3.10.0"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1"
+    },
+    "jsonify": {
+      "version": "0.0.0"
+    },
+    "jsonpointer": {
+      "version": "4.0.1"
+    },
+    "kind-of": {
+      "version": "6.0.2"
+    },
+    "lazy-cache": {
+      "version": "2.0.2"
+    },
+    "levn": {
+      "version": "0.3.0"
+    },
+    "liftoff": {
+      "version": "2.5.0"
+    },
+    "lodash": {
+      "version": "4.17.5"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1"
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1"
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0"
+    },
+    "lodash._getnative": {
+      "version": "3.9.1"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9"
+    },
+    "lodash._reescape": {
+      "version": "3.0.0"
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0"
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0"
+    },
+    "lodash._root": {
+      "version": "3.0.1"
+    },
+    "lodash.escape": {
+      "version": "3.2.0"
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4"
+    },
+    "lodash.keys": {
+      "version": "3.1.2"
+    },
+    "lodash.restparam": {
+      "version": "3.6.1"
+    },
+    "lodash.template": {
+      "version": "3.6.2"
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1"
+    },
+    "lru-cache": {
+      "version": "2.7.3"
+    },
+    "make-iterator": {
+      "version": "1.0.0",
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2"
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2"
+    },
+    "map-visit": {
+      "version": "1.0.0"
+    },
+    "micromatch": {
+      "version": "3.1.5"
+    },
+    "minimatch": {
+      "version": "3.0.4"
+    },
+    "minimist": {
+      "version": "1.2.0"
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1"
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8"
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0"
+    },
+    "multipipe": {
+      "version": "0.1.2"
+    },
+    "mute-stream": {
+      "version": "0.0.5"
+    },
+    "nanomatch": {
+      "version": "1.2.7",
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0"
+        }
+      }
+    },
+    "natives": {
+      "version": "1.1.1"
+    },
+    "no-arrowception": {
+      "version": "1.0.0"
+    },
+    "no-shadow-relaxed": {
+      "version": "1.0.1",
+      "dependencies": {
+        "eslint": {
+          "version": "0.24.1"
+        },
+        "ansi-regex": {
+          "version": "1.1.1"
+        },
+        "cli-width": {
+          "version": "1.1.1"
+        },
+        "doctrine": {
+          "version": "0.6.4"
+        },
+        "esutils": {
+          "version": "1.1.6"
+        },
+        "fast-levenshtein": {
+          "version": "1.0.7"
+        },
+        "globals": {
+          "version": "8.18.0"
+        },
+        "inquirer": {
+          "version": "0.8.5"
+        },
+        "levn": {
+          "version": "0.2.5"
+        },
+        "lodash": {
+          "version": "3.10.1"
+        },
+        "minimatch": {
+          "version": "2.0.10"
+        },
+        "mute-stream": {
+          "version": "0.0.4"
+        },
+        "object-assign": {
+          "version": "2.1.1"
+        },
+        "optionator": {
+          "version": "0.5.0"
+        },
+        "readline2": {
+          "version": "0.1.1"
+        },
+        "wordwrap": {
+          "version": "0.0.3"
+        },
+        "espree": {
+          "version": "2.2.5"
+        },
+        "strip-ansi": {
+          "version": "2.0.1"
+        },
+        "user-home": {
+          "version": "1.1.1"
+        }
+      }
+    },
+    "nsp": {
+      "version": "2.8.1",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3"
+        },
+        "cli-table": {
+          "version": "0.3.1"
+        },
+        "cvss": {
+          "version": "1.0.2"
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0"
+        },
+        "joi": {
+          "version": "6.10.1"
+        },
+        "nodesecurity-npm-utils": {
+          "version": "5.0.0"
+        },
+        "path-is-absolute": {
+          "version": "1.0.1"
+        },
+        "rc": {
+          "version": "1.2.1"
+        },
+        "semver": {
+          "version": "5.4.1"
+        },
+        "subcommand": {
+          "version": "2.1.0"
+        },
+        "wreck": {
+          "version": "6.3.0"
+        },
+        "ansi-regex": {
+          "version": "2.1.1"
+        },
+        "ansi-styles": {
+          "version": "2.2.1"
+        },
+        "boom": {
+          "version": "2.10.1"
+        },
+        "cliclopts": {
+          "version": "1.1.1"
+        },
+        "colors": {
+          "version": "1.0.3"
+        },
+        "debug": {
+          "version": "2.6.9"
+        },
+        "deep-extend": {
+          "version": "0.4.2"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5"
+        },
+        "extend": {
+          "version": "3.0.1"
+        },
+        "has-ansi": {
+          "version": "2.0.0"
+        },
+        "hoek": {
+          "version": "2.16.3"
+        },
+        "ini": {
+          "version": "1.3.4"
+        },
+        "isemail": {
+          "version": "1.2.0"
+        },
+        "minimist": {
+          "version": "1.2.0"
+        },
+        "moment": {
+          "version": "2.18.1"
+        },
+        "ms": {
+          "version": "2.0.0"
+        },
+        "strip-ansi": {
+          "version": "3.0.1"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1"
+        },
+        "supports-color": {
+          "version": "2.0.0"
+        },
+        "topo": {
+          "version": "1.1.0"
+        },
+        "xtend": {
+          "version": "4.0.1"
+        },
+        "agent-base": {
+          "version": "2.1.1",
+          "dependencies": {
+            "semver": {
+              "version": "5.0.3"
+            }
+          }
+        }
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1"
+    },
+    "object-assign": {
+      "version": "3.0.0"
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5"
+        },
+        "kind-of": {
+          "version": "3.2.2"
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6"
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4"
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0"
+            }
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1"
+    },
+    "object.defaults": {
+      "version": "1.1.0"
+    },
+    "object.map": {
+      "version": "1.0.1"
+    },
+    "object.pick": {
+      "version": "1.3.0"
+    },
+    "once": {
+      "version": "1.4.0"
+    },
+    "onetime": {
+      "version": "1.1.0"
+    },
+    "optionator": {
+      "version": "0.8.2"
+    },
+    "orchestrator": {
+      "version": "0.3.8"
+    },
+    "ordered-read-streams": {
+      "version": "0.1.0"
+    },
+    "os-homedir": {
+      "version": "1.0.2"
+    },
+    "parse-filepath": {
+      "version": "1.0.2"
+    },
+    "parse-passwd": {
+      "version": "1.0.0"
+    },
+    "pascalcase": {
+      "version": "0.1.1"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1"
+    },
+    "path-is-inside": {
+      "version": "1.0.2"
+    },
+    "path-parse": {
+      "version": "1.0.5"
+    },
+    "path-root": {
+      "version": "0.1.1"
+    },
+    "path-root-regex": {
+      "version": "0.1.2"
+    },
+    "pify": {
+      "version": "2.3.0"
+    },
+    "pinkie": {
+      "version": "2.0.4"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1"
+    },
+    "plugin-error": {
+      "version": "1.0.1",
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2"
+        },
+        "is-extendable": {
+          "version": "1.0.1"
+        }
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1"
+    },
+    "posix-character-classes": {
+      "version": "0.1.1"
+    },
+    "prelude-ls": {
+      "version": "1.1.2"
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3"
+    },
+    "process-nextick-args": {
+      "version": "2.0.0"
+    },
+    "progress": {
+      "version": "1.1.8"
+    },
+    "readable-stream": {
+      "version": "1.1.14"
+    },
+    "readline2": {
+      "version": "1.0.1"
+    },
+    "rechoir": {
+      "version": "0.6.2"
+    },
+    "regex-not": {
+      "version": "1.0.0"
+    },
+    "repeat-element": {
+      "version": "1.1.2"
+    },
+    "repeat-string": {
+      "version": "1.6.1"
+    },
+    "replace-ext": {
+      "version": "0.0.1"
+    },
+    "require-uncached": {
+      "version": "1.0.3"
+    },
+    "resolve": {
+      "version": "1.5.0"
+    },
+    "resolve-dir": {
+      "version": "1.0.1"
+    },
+    "resolve-from": {
+      "version": "1.0.1"
+    },
+    "resolve-url": {
+      "version": "0.2.1"
+    },
+    "restore-cursor": {
+      "version": "1.0.1"
+    },
+    "rimraf": {
+      "version": "2.6.2"
+    },
+    "run-async": {
+      "version": "0.1.0"
+    },
+    "rx": {
+      "version": "2.5.3"
+    },
+    "rx-lite": {
+      "version": "3.1.2"
+    },
+    "safe-buffer": {
+      "version": "5.1.1"
+    },
+    "semver": {
+      "version": "4.3.6"
+    },
+    "sequencify": {
+      "version": "0.0.7"
+    },
+    "set-getter": {
+      "version": "0.1.0"
+    },
+    "set-value": {
+      "version": "2.0.0"
+    },
+    "shelljs": {
+      "version": "0.6.1"
+    },
+    "sigmund": {
+      "version": "1.0.1"
+    },
+    "slice-ansi": {
+      "version": "0.0.4"
+    },
+    "snapdragon": {
+      "version": "0.8.1",
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5"
+        },
+        "is-descriptor": {
+          "version": "0.1.6"
+        },
+        "kind-of": {
+          "version": "5.1.0"
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1"
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2"
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7"
+    },
+    "source-map-resolve": {
+      "version": "0.5.1"
+    },
+    "source-map-url": {
+      "version": "0.4.0"
+    },
+    "sparkles": {
+      "version": "1.0.0"
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2"
+        },
+        "is-extendable": {
+          "version": "1.0.1"
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3"
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5"
+        },
+        "is-descriptor": {
+          "version": "0.1.6"
+        },
+        "kind-of": {
+          "version": "5.1.0"
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        }
+      }
+    },
+    "stream-consume": {
+      "version": "0.1.0"
+    },
+    "string-width": {
+      "version": "1.0.2"
+    },
+    "string_decoder": {
+      "version": "0.10.31"
+    },
+    "strip-ansi": {
+      "version": "3.0.1"
+    },
+    "strip-bom": {
+      "version": "1.0.0"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4"
+    },
+    "supports-color": {
+      "version": "2.0.0"
+    },
+    "table": {
+      "version": "3.8.3",
+      "dependencies": {
+        "string-width": {
+          "version": "2.1.1"
+        },
+        "ansi-regex": {
+          "version": "3.0.0"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0"
+        },
+        "strip-ansi": {
+          "version": "4.0.0"
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0"
+    },
+    "through": {
+      "version": "2.3.8"
+    },
+    "through2": {
+      "version": "2.0.3",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.4"
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "string_decoder": {
+          "version": "1.0.3"
+        }
+      }
+    },
+    "tildify": {
+      "version": "1.2.0"
+    },
+    "time-stamp": {
+      "version": "1.1.0"
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2"
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.1",
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5"
+        },
+        "is-descriptor": {
+          "version": "0.1.6"
+        },
+        "kind-of": {
+          "version": "5.1.0"
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1"
+    },
+    "type-check": {
+      "version": "0.3.2"
+    },
+    "typedarray": {
+      "version": "0.0.6"
+    },
+    "unc-path-regex": {
+      "version": "0.1.2"
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "dependencies": {
+        "set-value": {
+          "version": "0.4.3"
+        }
+      }
+    },
+    "unique-stream": {
+      "version": "1.0.0"
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0"
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4"
+        },
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0"
+    },
+    "use": {
+      "version": "2.0.2",
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5"
+        },
+        "is-descriptor": {
+          "version": "0.1.6"
+        },
+        "kind-of": {
+          "version": "5.1.0"
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2"
+            }
+          }
+        }
+      }
+    },
+    "user-home": {
+      "version": "2.0.0"
+    },
+    "util-deprecate": {
+      "version": "1.0.2"
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "dependencies": {
+        "user-home": {
+          "version": "1.1.1"
+        }
+      }
+    },
+    "vinyl": {
+      "version": "0.5.3"
+    },
+    "vinyl-fs": {
+      "version": "0.3.14",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.11"
+        },
+        "through2": {
+          "version": "0.6.5"
+        },
+        "vinyl": {
+          "version": "0.4.6"
+        },
+        "clone": {
+          "version": "0.2.0"
+        },
+        "readable-stream": {
+          "version": "1.0.34"
+        }
+      }
+    },
+    "which": {
+      "version": "1.3.0"
+    },
+    "wordwrap": {
+      "version": "1.0.0"
+    },
+    "wrappy": {
+      "version": "1.0.2"
+    },
+    "write": {
+      "version": "0.2.1"
+    },
+    "xml-escape": {
+      "version": "1.0.0"
+    },
+    "xtend": {
+      "version": "4.0.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   },
   "homepage": "https://github.com/nodesecurity/gulp-nsp#readme",
   "dependencies": {
-    "gulp-util": "^3.0.6",
-    "nsp": "^2.0.0"
+    "fancy-log": "^1.3.2",
+    "nsp": "^2.0.0",
+    "plugin-error": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^2.5.3",


### PR DESCRIPTION
Removed the dependency on gulp-util and introduced alternative libraries. I installed npm@2 to run shrinkwrap properly. Give me a reply if I messed up somehow.